### PR TITLE
DeprecateApplicationMainの対応

### DIFF
--- a/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
+++ b/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature DeprecateApplicationMain";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -331,6 +332,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature DeprecateApplicationMain";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/UpcomingFeatureFlagsSample/AppDelegate.swift
+++ b/UpcomingFeatureFlagsSample/AppDelegate.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
 


### PR DESCRIPTION
#5 

`@UIApplicationMain` の部分に警告が表示されるので、 `@main` に置き換える
（ `@NSApplicationMain` も同様）

【対応前】
<img width="522" alt="スクリーンショット 2024-07-09 19 53 51" src="https://github.com/yuukiw00w/iosdc-2024-poster/assets/9816269/852b8240-abef-4112-806d-f404b8cc34f5">
【対応後】
<img width="416" alt="スクリーンショット 2024-07-09 19 54 03" src="https://github.com/yuukiw00w/iosdc-2024-poster/assets/9816269/21edc1af-6e2d-4d33-831d-0f357e8d6bd9">
