### PR TITLE
BareSlashRegexLiterals対応

### DIFF
--- a/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
+++ b/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
@@ -374,7 +374,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -403,7 +403,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/UpcomingFeatureFlagsSample/RegexLiteralsSample.swift
+++ b/UpcomingFeatureFlagsSample/RegexLiteralsSample.swift
@@ -9,19 +9,9 @@ import Foundation
 
 func printRegexLiteralMatch() {
     let text = "My name is Noseda"
-    let pattern = "My name is (.*)"
+    let regex = /My name is (.*)/
 
-    do {
-        let regex = try NSRegularExpression(pattern: pattern)
-        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
-        
-        if let match = regex.firstMatch(in: text, options: [], range: nsRange) {
-            if let range = Range(match.range(at: 1), in: text) {
-                let matchedString = String(text[range])
-                print(matchedString)
-            }
-        }
-    } catch {
-        print("Invalid regex pattern")
+    if let match = text.matches(of: regex).first {
+        print(match.1)
     }
 }


### PR DESCRIPTION
#6 
`-enable-upcoming-feature BareSlashRegexLiterals` を付与する以外にも、 `Enable Bare Slash Regex Literals` をYESに設定することでも利用可能
NSRegularExpressionを使った従来の書き方ではなく、 `/My name is (.*)/` のように/で囲って正規表現リテラルを書くことができる