### PR TITLE
ForwardTrailingClosuresの対応

### DIFF
--- a/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
+++ b/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C4FEB7952C3E119B0058B9E5 /* UpcomingFeatureFlagsSampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FEB7942C3E119B0058B9E5 /* UpcomingFeatureFlagsSampleTests.swift */; };
 		C4FEB79C2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FEB79B2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift */; };
 		C4FEB79E2C3E51690058B9E5 /* RegexLiteralsSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FEB79D2C3E51690058B9E5 /* RegexLiteralsSample.swift */; };
+		C4FEB7A02C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FEB79F2C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +39,7 @@
 		C4FEB7942C3E119B0058B9E5 /* UpcomingFeatureFlagsSampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingFeatureFlagsSampleTests.swift; sourceTree = "<group>"; };
 		C4FEB79B2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConciseMagicFileSample.swift; sourceTree = "<group>"; };
 		C4FEB79D2C3E51690058B9E5 /* RegexLiteralsSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexLiteralsSample.swift; sourceTree = "<group>"; };
+		C4FEB79F2C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardTrailingClosuresSample.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +86,7 @@
 				C4FEB78A2C3D51910058B9E5 /* ExistentialAnySample.swift */,
 				C4FEB79B2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift */,
 				C4FEB79D2C3E51690058B9E5 /* RegexLiteralsSample.swift */,
+				C4FEB79F2C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift */,
 				C4FEB75E2C3CF75F0058B9E5 /* Assets.xcassets */,
 				C4FEB7602C3CF75F0058B9E5 /* Preview Content */,
 			);
@@ -209,6 +212,7 @@
 				C4FEB78B2C3D51910058B9E5 /* ExistentialAnySample.swift in Sources */,
 				C4FEB75D2C3CF75E0058B9E5 /* ContentView.swift in Sources */,
 				C4FEB79C2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift in Sources */,
+				C4FEB7A02C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift in Sources */,
 				C4FEB75B2C3CF75E0058B9E5 /* UpcomingFeatureFlagsSampleApp.swift in Sources */,
 				C4FEB79E2C3E51690058B9E5 /* RegexLiteralsSample.swift in Sources */,
 			);
@@ -374,7 +378,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -403,7 +407,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/UpcomingFeatureFlagsSample/ContentView.swift
+++ b/UpcomingFeatureFlagsSample/ContentView.swift
@@ -24,6 +24,11 @@ struct ContentView: View {
                 Button("RegexLiteralsSample") {
                     printRegexLiteralMatch()
                 }
+                Button("ForwardTrailingClosuresSample") {
+                    forwardTrailingClosuresSample {
+                        print("expected: first closure")
+                    }
+                }
             }.padding()
         }
         .padding()

--- a/UpcomingFeatureFlagsSample/ForwardTrailingClosuresSample.swift
+++ b/UpcomingFeatureFlagsSample/ForwardTrailingClosuresSample.swift
@@ -1,0 +1,16 @@
+//
+//  ForwardTrailingClosuresSample.swift
+//  UpcomingFeatureFlagsSample
+//
+//  Created by 野瀬田 裕樹 on 2024/07/10.
+//
+
+import Foundation
+
+func forwardTrailingClosuresSample(
+    first: () -> Void = { print("first") },
+    second: () -> Void = { print("second") }
+) {
+    first()
+    second()
+}


### PR DESCRIPTION
#9
関数の引数で複数クロージャが存在する場合、前の方から評価されるようになる
これにより、例えばデフォルト値の存在する複数のクロージャのうちを一つをtrailing closureで記述した場合に挙動が変わる 
そのような場合、ForwardTrailingClosuresを有効にすると前の方にあるクロージャとして認識するが、従来挙動では後ろの方にあるクロージャとして認識する