### PR TITLE
ImplicitOpenExistentials対応

### DIFF
--- a/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
+++ b/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		C4FEB79C2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FEB79B2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift */; };
 		C4FEB79E2C3E51690058B9E5 /* RegexLiteralsSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FEB79D2C3E51690058B9E5 /* RegexLiteralsSample.swift */; };
 		C4FEB7A02C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FEB79F2C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift */; };
+		C4FEB7A22C3E70970058B9E5 /* ImplicitOpenExistentialsSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FEB7A12C3E70970058B9E5 /* ImplicitOpenExistentialsSample.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,6 +41,7 @@
 		C4FEB79B2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConciseMagicFileSample.swift; sourceTree = "<group>"; };
 		C4FEB79D2C3E51690058B9E5 /* RegexLiteralsSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexLiteralsSample.swift; sourceTree = "<group>"; };
 		C4FEB79F2C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardTrailingClosuresSample.swift; sourceTree = "<group>"; };
+		C4FEB7A12C3E70970058B9E5 /* ImplicitOpenExistentialsSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitOpenExistentialsSample.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +89,7 @@
 				C4FEB79B2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift */,
 				C4FEB79D2C3E51690058B9E5 /* RegexLiteralsSample.swift */,
 				C4FEB79F2C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift */,
+				C4FEB7A12C3E70970058B9E5 /* ImplicitOpenExistentialsSample.swift */,
 				C4FEB75E2C3CF75F0058B9E5 /* Assets.xcassets */,
 				C4FEB7602C3CF75F0058B9E5 /* Preview Content */,
 			);
@@ -214,6 +217,7 @@
 				C4FEB79C2C3E11EA0058B9E5 /* ConciseMagicFileSample.swift in Sources */,
 				C4FEB7A02C3E5BFF0058B9E5 /* ForwardTrailingClosuresSample.swift in Sources */,
 				C4FEB75B2C3CF75E0058B9E5 /* UpcomingFeatureFlagsSampleApp.swift in Sources */,
+				C4FEB7A22C3E70970058B9E5 /* ImplicitOpenExistentialsSample.swift in Sources */,
 				C4FEB79E2C3E51690058B9E5 /* RegexLiteralsSample.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/UpcomingFeatureFlagsSample/ContentView.swift
+++ b/UpcomingFeatureFlagsSample/ContentView.swift
@@ -29,6 +29,10 @@ struct ContentView: View {
                         print("expected: first closure")
                     }
                 }
+                Button("implicitOpenExistentialsSample") {
+                    implicitOpenExistentialsSample(anyP: PImpl())
+                    implicitOpenExistentialsSample2(anyP: PImpl())
+                }
             }.padding()
         }
         .padding()

--- a/UpcomingFeatureFlagsSample/ImplicitOpenExistentialsSample.swift
+++ b/UpcomingFeatureFlagsSample/ImplicitOpenExistentialsSample.swift
@@ -1,0 +1,33 @@
+//
+//  ImplicitOpenExistentialsSample.swift
+//  UpcomingFeatureFlagsSample
+//
+//  Created by 野瀬田 裕樹 on 2024/07/10.
+//
+
+import Foundation
+
+protocol P {
+    associatedtype A
+    func getA() -> A
+}
+
+struct PImpl: P {
+    func getA() -> Int {
+        3
+    }
+}
+
+func implicitOpenExistentialsSample(anyP: any P) {
+    func returnA<Value: P>(_ value: Value) -> Value.A { value.getA() }
+    print(returnA(anyP))
+}
+
+func implicitOpenExistentialsSample2(anyP: any P) {
+    func returnTypeSelf<Value>(_: Value.Type) -> Value.Type { Value.self }
+    
+    let anyPType = type(of: anyP)
+    
+    print(returnTypeSelf(_openExistential(anyPType, do: returnTypeSelf)))
+//    print(returnTypeSelf(anyPType))
+}


### PR DESCRIPTION
#7
実際にはImplicitOpenExistentialsのSwift Evolutionに記載のサンプルは-enable-upcoming-feature ImplicitOpenExistentialsを使用しなくても動作する
ImplicitOpenExistentialsのフラグ実装が後追いになった関係で、Any.Typeの存在型メタタイプを開くことができるようになる機能についてはSwift 6環境のSwift 5互換モードでImplicitOpenExistentialsを有効にしたときに使えるようになる
しかし、ImplicitOpenExistentialsを有効にしなくても5.10時点では通常の存在型はgenericsの関数に入れるときにはその基礎となる型にバインドされる（開かれる）ので、ビルドエラーにならない