### PR TITLE
DisableOutwardActorInference対応

### DIFF
--- a/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
+++ b/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -415,7 +415,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/UpcomingFeatureFlagsSample/DisableOutwardActorInferenceSample.swift
+++ b/UpcomingFeatureFlagsSample/DisableOutwardActorInferenceSample.swift
@@ -12,6 +12,7 @@ struct MainActorWrapper<Wrapped> {
     @MainActor var wrappedValue: Wrapped
 }
 
+@MainActor
 struct MainActorIsolationInferenceSample {
     @MainActorWrapper var intValue: Int = 0
     nonisolated func nonisolatedFunc() {}


### PR DESCRIPTION
#3
propertyWrapperを使う側がpropertyWrapperのactorを引き継ぐ仕様が無効化される
従来通りの挙動にしたい場合は明示的にglobal actorを付与する