### PR TITLE
GlobalConcurrency対応

### DIFF
--- a/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
+++ b/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -419,7 +419,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/UpcomingFeatureFlagsSample/GlobalConcurrencySample.swift
+++ b/UpcomingFeatureFlagsSample/GlobalConcurrencySample.swift
@@ -9,4 +9,5 @@ import Foundation
 
 final class GlobalConcurrencySample {}
 
+@MainActor
 var sampleGlobalVar: GlobalConcurrencySample = .init()


### PR DESCRIPTION
#1
グローバル変数にデータ競合の可能性があると警告が出るようになるので、@MainActorのようなglobal actorで隔離するか、immutableかつSendableな変数に変更する