### PR TITLE
IsolatedDefaultValues対応

### DIFF
--- a/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
+++ b/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
@@ -394,7 +394,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency -enable-upcoming-feature IsolatedDefaultValues";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -423,7 +423,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency -enable-upcoming-feature IsolatedDefaultValues";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/UpcomingFeatureFlagsSample/DisableOutwardActorInferenceSample.swift
+++ b/UpcomingFeatureFlagsSample/DisableOutwardActorInferenceSample.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 @propertyWrapper
+@MainActor
 struct MainActorWrapper<Wrapped> {
     @MainActor var wrappedValue: Wrapped
 }

--- a/UpcomingFeatureFlagsSample/IsolatedDefaultValuesSample.swift
+++ b/UpcomingFeatureFlagsSample/IsolatedDefaultValuesSample.swift
@@ -9,16 +9,19 @@ import Foundation
 
 @globalActor
 struct SampleGlobalActor {
-  actor ActorType { }
-  static let shared: ActorType = ActorType()
+    actor ActorType { }
+    static let shared: ActorType = ActorType()
 }
 
 @MainActor func requiresMainActor() -> Int { 1 }
 @SampleGlobalActor func requiresAnotherActor() -> Int { 2 }
 
 class IsolatedDefaultValuesSampleClass {
-  @MainActor var x1 = requiresMainActor()
-  @SampleGlobalActor var x2 = requiresAnotherActor()
+    @MainActor var x1 = requiresMainActor()
+    @SampleGlobalActor var x2 = requiresAnotherActor()
 
-  nonisolated init() {}
+    nonisolated init() async {
+        x1 = await requiresMainActor()
+        x2 = await requiresAnotherActor()
+    }
 }


### PR DESCRIPTION
#2
デフォルト値が設定されているstored propertyにおいて、そのデフォルト値の式と同じActorでstored propertyが隔離される これは関数の引数におけるデフォルト値においても同様で、関数自体も同じActorで隔離されるようになる