### PR TITLE
ImportObjcForwardDeclarations対応

### DIFF
--- a/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
+++ b/UpcomingFeatureFlagsSample.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency -enable-upcoming-feature IsolatedDefaultValues";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency -enable-upcoming-feature IsolatedDefaultValues -enable-upcoming-feature ImportObjcForwardDeclarations";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -446,7 +446,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency -enable-upcoming-feature IsolatedDefaultValues";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature GlobalConcurrency -enable-upcoming-feature IsolatedDefaultValues -enable-upcoming-feature ImportObjcForwardDeclarations";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.noseda.UpcomingFeatureFlagsSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/UpcomingFeatureFlagsSample/ImportObjcForwardDeclarationsSample.swift
+++ b/UpcomingFeatureFlagsSample/ImportObjcForwardDeclarationsSample.swift
@@ -10,7 +10,7 @@ import Foundation
 func importObjcForwardDeclarationsSample() {
     let sample1 = ForwardDeclaredSampleClass1()
     print(sample1)
-//    let sample2 = sample1.createSample()!
-//    print(sample2)
+    let sample2 = sample1.createSample()!
+    print(sample2)
 }
 

--- a/UpcomingFeatureFlagsSample/UpcomingFeatureFlagsSample-Bridging-Header.h
+++ b/UpcomingFeatureFlagsSample/UpcomingFeatureFlagsSample-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "ForwardDeclaredSample.h"
+//#import "ForwardDeclaredSample2.h"


### PR DESCRIPTION
#4
前方宣言されたものを使用した関数などはImportObjcForwardDeclarationsが無効な状態では使えず、前方宣言されたものを使いたい場合は全てimportが必要だったが、ImportObjcForwardDeclarationsを有効にすると全てをimportする必要がなくなる